### PR TITLE
No test prefix

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -17,8 +17,8 @@ jobs:
         env:
           HARNESS_PERL_SWITCHES: -MDevel::Cover
         run: |
-          sed 's/\/opt\/webwork\//\/__w\/webwork3\//g' conf/webwork3.dist.yml > conf/webwork3.yml
-          sed 's/\/opt\/webwork\//\/__w\/webwork3\//g' conf/ww3-dev.dist.yml > conf/ww3-dev.yml
+          cp conf/webwork3.dist.yml conf/webwork3.yml
+          cp conf/ww3-dev.dist.yml conf/ww3-dev.yml
           perl t/db/build_db.pl
           prove -r t
 

--- a/conf/webwork3.dist.yml
+++ b/conf/webwork3.dist.yml
@@ -1,12 +1,12 @@
 ---
 secrets:
   - 3cdf63327fcf77deaed1d200df4b9fee66af2326
-webwork3_home: /opt/webwork/webwork3
+webwork3_home: .
 
 # Database settings
 
 # For the sqlite database
-database_dsn: dbi:SQLite:/opt/webwork/webwork3/t/db/sample_db.sqlite
+database_dsn: dbi:SQLite:./t/db/sample_db.sqlite
 # For mysql or mariadb
 #database_dsn: dbi:mysql:dbname=webwork3
 

--- a/conf/ww3-dev.dist.yml
+++ b/conf/ww3-dev.dist.yml
@@ -11,10 +11,12 @@ webwork3_home: .
 # database that is different than others.
 
 # For the sqlite database
-test_database_dsn: dbi:SQLite:./t/db/sample_db.sqlite
+database_dsn: dbi:SQLite:./t/db/sample_db.sqlite
 # For mysql or mariadb
 # note: choose a database
-#test_database_dsn: dbi:mysql:dbname=webwork3_test
+#database_dsn: dbi:mysql:dbname=webwork3_test
 
-
-
+# Database credentials for mysql or mariadb.
+# These are ignored if the 'sqlite' database is used.
+database_user: webworkWrite
+database_password: password

--- a/t/db/001_courses.t
+++ b/t/db/001_courses.t
@@ -34,7 +34,7 @@ die "The file $config_file does not exist.  Did you make a copy of it from ww3-d
 my $config = LoadFile($config_file);
 
 my $schema =
-	DB::Schema->connect($config->{test_database_dsn}, $config->{database_user}, $config->{database_password});
+	DB::Schema->connect($config->{database_dsn}, $config->{database_user}, $config->{database_password});
 
 # $schema->storage->debug(1);  # print out the SQL commands.
 

--- a/t/db/002_course_settings.t
+++ b/t/db/002_course_settings.t
@@ -38,7 +38,7 @@ die "The file $config_file does not exist.  Did you make a copy of it from ww3-d
 my $config = LoadFile($config_file);
 
 my $schema =
-	DB::Schema->connect($config->{test_database_dsn}, $config->{database_user}, $config->{database_password});
+	DB::Schema->connect($config->{database_dsn}, $config->{database_user}, $config->{database_password});
 
 # $schema->storage->debug(1);  # print out the SQL commands.
 

--- a/t/db/003_users.t
+++ b/t/db/003_users.t
@@ -35,7 +35,7 @@ if (-e $config_file) {
 }
 
 my $schema =
-	DB::Schema->connect($config->{test_database_dsn}, $config->{database_user}, $config->{database_password});
+	DB::Schema->connect($config->{database_dsn}, $config->{database_user}, $config->{database_password});
 
 # $schema->storage->debug(1);  # print out the SQL commands.
 

--- a/t/db/004_course_users.t
+++ b/t/db/004_course_users.t
@@ -33,7 +33,7 @@ die "The file $config_file does not exist.  Did you make a copy of it from ww3-d
 my $config = LoadFile($config_file);
 
 my $schema =
-	DB::Schema->connect($config->{test_database_dsn}, $config->{database_user}, $config->{database_password});
+	DB::Schema->connect($config->{database_dsn}, $config->{database_user}, $config->{database_password});
 
 # $schema->storage->debug(1);  # print out the SQL commands.
 

--- a/t/db/005_hwsets.t
+++ b/t/db/005_hwsets.t
@@ -36,7 +36,7 @@ die "The file $config_file does not exist.  Did you make a copy of it from ww3-d
 my $config = LoadFile($config_file);
 
 my $schema =
-	DB::Schema->connect($config->{test_database_dsn}, $config->{database_user}, $config->{database_password});
+	DB::Schema->connect($config->{database_dsn}, $config->{database_user}, $config->{database_password});
 
 my $strp = DateTime::Format::Strptime->new(pattern => '%FT%T', on_error => 'croak');
 

--- a/t/db/006_quizzes.t
+++ b/t/db/006_quizzes.t
@@ -35,7 +35,7 @@ die "The file $config_file does not exist.  Did you make a copy of it from ww3-d
 my $config = LoadFile($config_file);
 
 my $schema =
-	DB::Schema->connect($config->{test_database_dsn}, $config->{database_user}, $config->{database_password});
+	DB::Schema->connect($config->{database_dsn}, $config->{database_user}, $config->{database_password});
 
 my $strp = DateTime::Format::Strptime->new(pattern => '%FT%T', on_error => 'croak');
 

--- a/t/db/007_user_set.t
+++ b/t/db/007_user_set.t
@@ -37,7 +37,7 @@ die "The file $config_file does not exist.  Did you make a copy of it from ww3-d
 my $config = LoadFile($config_file);
 
 my $schema =
-	DB::Schema->connect($config->{test_database_dsn}, $config->{database_user}, $config->{database_password});
+	DB::Schema->connect($config->{database_dsn}, $config->{database_user}, $config->{database_password});
 
 my $strp = DateTime::Format::Strptime->new(pattern => '%FT%T', on_error => 'croak');
 

--- a/t/db/008_problem_pools.t
+++ b/t/db/008_problem_pools.t
@@ -34,7 +34,7 @@ die "The file $config_file does not exist.  Did you make a copy of it from ww3-d
 my $config = LoadFile($config_file);
 
 my $schema =
-	DB::Schema->connect($config->{test_database_dsn}, $config->{database_user}, $config->{database_password});
+	DB::Schema->connect($config->{database_dsn}, $config->{database_user}, $config->{database_password});
 
 # $schema->storage->debug(1);  # print out the SQL commands.
 

--- a/t/db/009_problems.t
+++ b/t/db/009_problems.t
@@ -35,7 +35,7 @@ die "The file $config_file does not exist.  Did you make a copy of it from ww3-d
 my $config = LoadFile($config_file);
 
 my $schema =
-	DB::Schema->connect($config->{test_database_dsn}, $config->{database_user}, $config->{database_password});
+	DB::Schema->connect($config->{database_dsn}, $config->{database_user}, $config->{database_password});
 
 # $schema->storage->debug(1);  # print out the SQL commands.
 

--- a/t/db/010_set_versions.t
+++ b/t/db/010_set_versions.t
@@ -35,7 +35,7 @@ die "The file $config_file does not exist.  Did you make a copy of it from ww3-d
 my $config = LoadFile($config_file);
 
 my $schema =
-	DB::Schema->connect($config->{test_database_dsn}, $config->{database_user}, $config->{database_password});
+	DB::Schema->connect($config->{database_dsn}, $config->{database_user}, $config->{database_password});
 
 # $schema->storage->debug(1);  # print out the SQL commands.
 

--- a/t/db/build_db.pl
+++ b/t/db/build_db.pl
@@ -29,23 +29,22 @@ use DB::Schema;
 use DB;
 use DB::TestUtils qw/loadCSV/;
 
-# load some configuration for the database:
 my $verbose = 1;
-my $config;
+
+# load some configuration for the database:
 my $config_file = "$main::ww3_dir/conf/ww3-dev.yml";
-if (-e $config_file) {
-	$config = LoadFile($config_file);
-} else {
-	die "The file $config_file does not exist.  Did you make a copy of it from ww3-dev.dist.yml ?";
-}
+die "The file $config_file does not exist.  Did you make a copy of it from ww3-dev.dist.yml ?"
+	unless (-e $config_file);
+
+my $config = LoadFile($config_file);
 
 # load the database
 my $schema =
-	DB::Schema->connect($config->{test_database_dsn}, $config->{database_user}, $config->{test_database_password});
+	DB::Schema->connect($config->{database_dsn}, $config->{database_user}, $config->{database_password});
 
 # $schema->storage->debug(1);  # print out the SQL commands.
 
-say "restoring the database with dbi: $config->{test_database_dsn}" if $verbose;
+say "restoring the database with dbi: $config->{database_dsn}" if $verbose;
 
 $schema->deploy({ add_drop_table => 1 });    ## create the database based on the schema
 

--- a/t/mojolicious/002_courses.t
+++ b/t/mojolicious/002_courses.t
@@ -24,16 +24,11 @@ use Clone qw/clone/;
 
 use YAML::XS qw/LoadFile/;
 
-my $config;
 my $config_file = "$main::ww3_dir/conf/ww3-dev.yml";
-if (-e $config_file) {
-	$config                      = clone(LoadFile($config_file));
-	$config->{database_dsn}      = $config->{test_database_dsn};
-	$config->{database_user}     = $config->{database_user};
-	$config->{database_password} = $config->{database_password};
-} else {
-	die "The file $config_file does not exist.  Did you make a copy of it from ww3-dev.dist.yml ?";
-}
+die "The file $config_file does not exist.  Did you make a copy of it from ww3-dev.dist.yml ?"
+	unless (-e $config_file);
+
+my $config = clone(LoadFile($config_file));
 
 my $t;
 

--- a/t/mojolicious/003_users.t
+++ b/t/mojolicious/003_users.t
@@ -23,20 +23,15 @@ use YAML qw/LoadFile/;
 
 # Test the api with common "users" routes
 
-my $config;
 my $config_file = "$main::ww3_dir/conf/ww3-dev.yml";
-if (-e $config_file) {
-	$config                      = clone(LoadFile($config_file));
-	$config->{database_dsn}      = $config->{test_database_dsn};
-	$config->{database_user}     = $config->{database_user};
-	$config->{database_password} = $config->{database_password};
-} else {
-	die "The file $config_file does not exist.  Did you make a copy of it from ww3-dev.dist.yml ?";
-}
+die "The file $config_file does not exist.  Did you make a copy of it from ww3-dev.dist.yml ?"
+	unless (-e $config_file);
+
+my $config = clone(LoadFile($config_file));
 
 # set up the database:
 my $schema =
-	DB::Schema->connect($config->{test_database_dsn}, $config->{database_user}, $config->{database_password});
+	DB::Schema->connect($config->{database_dsn}, $config->{database_user}, $config->{database_password});
 
 # remove the maggie user if exists in the database
 my $maggie = $schema->resultset("User")->find({ username => "maggie" });

--- a/t/mojolicious/004_course_users.t
+++ b/t/mojolicious/004_course_users.t
@@ -22,22 +22,17 @@ use DB::Schema;
 use Clone qw/clone/;
 use YAML::XS qw/LoadFile/;
 
-my $config;
 my $config_file = "$main::ww3_dir/conf/ww3-dev.yml";
-if (-e $config_file) {
-	$config                      = clone(LoadFile($config_file));
-	$config->{database_dsn}      = $config->{test_database_dsn};
-	$config->{database_user}     = $config->{database_user};
-	$config->{database_password} = $config->{database_password};
-} else {
-	die "The file $config_file does not exist.  Did you make a copy of it from ww3-dev.dist.yml ?";
-}
+die "The file $config_file does not exist.  Did you make a copy of it from ww3-dev.dist.yml ?"
+	unless (-e $config_file);
+
+my $config = clone(LoadFile($config_file));
 
 # Test the api with common "courses" routes
 
 # set up the database:
 my $schema =
-	DB::Schema->connect($config->{test_database_dsn}, $config->{database_user}, $config->{database_password});
+	DB::Schema->connect($config->{database_dsn}, $config->{database_user}, $config->{database_password});
 
 my $t;
 

--- a/t/mojolicious/005_problem_sets.t
+++ b/t/mojolicious/005_problem_sets.t
@@ -23,16 +23,11 @@ use Clone qw/clone/;
 use YAML::XS qw/LoadFile/;
 use DB::TestUtils qw/loadCSV/;
 
-my $config;
 my $config_file = "$main::ww3_dir/conf/ww3-dev.yml";
-if (-e $config_file) {
-	$config                      = clone(LoadFile($config_file));
-	$config->{database_dsn}      = $config->{test_database_dsn};
-	$config->{database_user}     = $config->{database_user};
-	$config->{database_password} = $config->{database_password};
-} else {
-	die "The file $config_file does not exist.  Did you make a copy of it from ww3-dev.dist.yml ?";
-}
+die "The file $config_file does not exist.  Did you make a copy of it from ww3-dev.dist.yml ?"
+	unless (-e $config_file);
+
+my $config = clone(LoadFile($config_file));
 
 my $strp = DateTime::Format::Strptime->new(pattern => '%FT%T', on_error => 'croak');
 
@@ -40,7 +35,7 @@ my $strp = DateTime::Format::Strptime->new(pattern => '%FT%T', on_error => 'croa
 
 # set up the database:
 my $schema =
-	DB::Schema->connect($config->{test_database_dsn}, $config->{database_user}, $config->{database_password});
+	DB::Schema->connect($config->{database_dsn}, $config->{database_user}, $config->{database_password});
 
 my $t;
 

--- a/t/mojolicious/006_quizzes.t
+++ b/t/mojolicious/006_quizzes.t
@@ -24,16 +24,11 @@ use DB::TestUtils qw/loadSchema loadCSV/;
 use Clone qw/clone/;
 use YAML::XS qw/LoadFile/;
 
-my $config;
 my $config_file = "$main::ww3_dir/conf/ww3-dev.yml";
-if (-e $config_file) {
-	$config                      = clone(LoadFile($config_file));
-	$config->{database_dsn}      = $config->{test_database_dsn};
-	$config->{database_user}     = $config->{database_user};
-	$config->{database_password} = $config->{database_password};
-} else {
-	die "The file $config_file does not exist.  Did you make a copy of it from ww3-dev.dist.yml ?";
-}
+die "The file $config_file does not exist.  Did you make a copy of it from ww3-dev.dist.yml ?"
+	unless (-e $config_file);
+
+my $config = clone(LoadFile($config_file));
 
 my $strp = DateTime::Format::Strptime->new(pattern => '%FT%T', on_error => 'croak');
 
@@ -41,7 +36,7 @@ my $strp = DateTime::Format::Strptime->new(pattern => '%FT%T', on_error => 'croa
 
 # set up the database:
 my $schema =
-	DB::Schema->connect($config->{test_database_dsn}, $config->{database_user}, $config->{database_password});
+	DB::Schema->connect($config->{database_dsn}, $config->{database_user}, $config->{database_password});
 
 my $t;
 


### PR DESCRIPTION
This is what I meant with the `_test` prefix.  This simplifies things a lot.

Since you made the paths relative in ww3-dev.dist.yml, I also did so in webwork3.dist.yml.  As such there is no need for the `sed` statements in the unit test workflow.  Instead a simple `cp` will suffice.