### PR TITLE
Replace eslint-disable and any types with a horse by another name.

### DIFF
--- a/src/store/models/problem_sets.ts
+++ b/src/store/models/problem_sets.ts
@@ -83,12 +83,9 @@ export class ProblemSet extends Model(
 				`The dates(s) '${invalid_dates.join(', ')}' are not valid for ${this.constructor.name}.`);
 		}
 
-		/* eslint-disable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call,
-		  @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment */
 		Object.keys(dates).forEach(key => {
-			(this.set_dates as any)[key] = parseNonNegInt((dates as any)[key]);
+			(this.set_dates as Dictionary<generic>)[key] = parseNonNegInt(dates[key] as string | number);
 		});
-		/* eslint-enable */
 	}
 
 	setParams(params: Dictionary<generic> = {}) {

--- a/src/store/models/problems.ts
+++ b/src/store/models/problems.ts
@@ -40,7 +40,7 @@ export interface ProblemParams extends Dictionary<generic> {
 }
 
 export class Problem extends Model(
-	[], ['problem_id', 'set_id', 'id', 'problem_number', 'problem_version'],
+	[], ['problem_id', 'set_id', 'seed', 'id', 'problem_number', 'problem_version'],
 	[], ['problem_params', 'renderer_params'],
 	{
 		problem_id: { field_type: 'non_neg_int', default_value: 0 },
@@ -123,7 +123,7 @@ export class Problem extends Model(
 			problemSeed: this.renderer_params.problemSeed,
 			outputFormat: this.renderer_params.outputFormat,
 			sourceFilePath: this.path(), // will this respect inheritance?
-			problemNumber: this.problem_number ?? this.problem_params.library_id,
+			problemNumber: this.problem_number ?? this.problem_params.library_id ?? 0,
 			answerPrefix: this.renderer_params.answerPrefix,
 			permissionLevel: this.renderer_params.permission_level,
 			language: 'en',

--- a/src/store/modules/set_problems.ts
+++ b/src/store/modules/set_problems.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-tabs */
 import { api } from 'boot/axios';
 import { Commit } from 'vuex';
 // import { StateInterface } from '../index';
@@ -28,6 +27,7 @@ export default {
 			const _sets_to_parse = response.data as Array<ParseableProblem>;
 			commit('SET_SET_PROBLEMS)', _sets_to_parse.map((problem)=> parseProblem(problem, 'Set')));
 		},
+		/* eslint-disable no-tabs */
 		// async updateSet(
 		// 	{ commit, rootState }: { commit: Commit; rootState: StateInterface },
 		// 	 _set: SetProblem): Promise<SetProblem> {
@@ -42,14 +42,17 @@ export default {
 		// 	}
 		// 	return set;
 		// }
+		/* eslint-enable */
 	},
 	mutations: {
 		SET_SET_PROBLEMS(state: SetProblemsState, _set_problems: Array<Problem>): void {
 			state.problems = _set_problems;
 		},
+		/* eslint-disable no-tabs */
 		// UPDATE_PROBLEM_SET(state: SetProblemsState, _set: SetProblem): void {
 		// 	const index = state.problem_sets.findIndex((s: SetProblem) => s.set_id === _set.set_id);
 		// 	state.problem_sets[index] = _set;
 		// }
+		/* eslint-enable */
 	}
 };


### PR DESCRIPTION
Replace the eslint-disable statements with type assertions.  This is not a whole lot better, but it at least makes it clear what the expected types are.

Note that when eslint-disable is used, make the usage more precise.  Do not just disable it for the whole file.  See the change in src/store/modules/set_problems.ts.

Also fix a few other glaring issues.