### PR TITLE
fix reactivity of problem set details

### DIFF
--- a/src/common/views.ts
+++ b/src/common/views.ts
@@ -1,26 +1,12 @@
 /* This file contains common functions and constants needs for general use */
 
 import { date } from 'quasar';
-import type { HomeworkSetDates, ReviewSetDates, QuizDates } from 'src/common/models/problem_sets';
 
 export function formatDate(_date_to_format: string | number) {
 	const _date = new Date();
 	_date.setTime(parseInt(`${_date_to_format}`) * 1000); //js dates have milliseconds instead of standard unix epoch
 	return date.formatDate(_date, 'MM-DD-YYYY [at] h:mmA'); // have the format changeable?
 }
-
-export const checkHWDates = (dates: HomeworkSetDates, enable_reduced_scoring?: boolean): boolean | string =>
-	enable_reduced_scoring && dates.reduced_scoring ?
-		(dates.open <= dates.reduced_scoring && dates.reduced_scoring <= dates.due  && dates.due <= dates.answer) :
-		(dates.open <= dates.due && dates.due <= dates.answer) ||
-		'The dates must be in order';
-
-export const checkQuizDates = (dates: QuizDates): boolean | string =>
-	dates.open <= dates.due && dates.due <= dates.answer ||
-		'The dates must be in order';
-
-export const checkReviewSetDates = (dates: ReviewSetDates): boolean | string => dates.open <= dates.closed ||
-		'The dates must be in order';
 
 export interface ViewInfo {
 	name: string;

--- a/src/components/common/DateTimeInput.vue
+++ b/src/components/common/DateTimeInput.vue
@@ -37,15 +37,14 @@ export default defineComponent({
 	},
 	emits: ['update:modelValue'],
 	setup (props, { emit }) {
-		const model_value = ref<number>(props.modelValue);
+		const model_value = computed(() => props.modelValue);
 		const model_string = ref<string>(date.formatDate((props.modelValue || Date.now()) * 1000, 'YYYY-MM-DD HH:mm'));
 		const error_message = computed(() => props.errorMessage);
 		const is_valid = computed(() => error_message.value === '');
 
 		watch(() => model_string.value, () => {
 			logger.debug('[DateTimeInput] model string has changed, telling parent.');
-			model_value.value = date.extractDate(model_string.value, 'YYYY-MM-DD HH:mm').getTime() / 1000;
-			emit('update:modelValue', model_value.value);
+			emit('update:modelValue', date.extractDate(model_string.value, 'YYYY-MM-DD HH:mm').getTime() / 1000);
 		});
 
 		return {

--- a/src/components/common/InputWithBlur.vue
+++ b/src/components/common/InputWithBlur.vue
@@ -18,15 +18,15 @@ export default defineComponent({
 	setup(props, { emit }) {
 		const model_value = ref(props.modelValue);
 
-		watch(() => props.modelValue, () => {
-			logger.debug(`[InputWithBlur]: old value: ${model_value.value}`);
+		watch(() => props.modelValue, (new_str, old_str) => {
+			logger.debug(`[InputWithBlur] parent has changed me from: ${old_str} to:${new_str}`);
 			model_value.value = props.modelValue;
-			logger.debug(`[InputWithBlur]: new value: ${model_value.value}`);
 		});
 
 		return {
 			model_value,
 			sendValue: () => {
+				logger.debug('[InputWithBlur] My input has changed, telling parent.');
 				emit('update:modelValue', model_value.value);
 			}
 		};

--- a/src/components/instructor/SetDetails/HomeworkDates.vue
+++ b/src/components/instructor/SetDetails/HomeworkDates.vue
@@ -5,15 +5,15 @@
 		<td>
 			<date-time-input
 				v-model="hw_dates.open"
-				:validation="checkDates"
+				:errorMessage="error_message"
 			/></td>
 	</tr>
 	<tr v-if="enable_reduced_scoring">
 		<td class="header">Reduced Scoring Date</td>
 		<td>
 			<date-time-input
-			v-model="hw_dates.reduced_scoring"
-			:validation="checkDates"
+				v-model="hw_dates.reduced_scoring"
+				:errorMessage="error_message"
 			/>
 		</td>
 	</tr>
@@ -22,7 +22,7 @@
 		<td>
 			<date-time-input
 				v-model="hw_dates.due"
-				:validation="checkDates"
+				:errorMessage="error_message"
 			/></td>
 	</tr>
 	<tr>
@@ -30,7 +30,7 @@
 		<td>
 			<date-time-input
 				v-model="hw_dates.answer"
-				:validation="checkDates"
+				:errorMessage="error_message"
 			/></td>
 	</tr>
 </template>
@@ -38,9 +38,9 @@
 <script lang="ts">
 import { defineComponent, ref, computed, watch } from 'vue';
 import type { PropType } from 'vue';
-import { checkHWDates } from 'src/common/views';
 import { HomeworkSetDates } from 'src/common/models/problem_sets';
 import DateTimeInput from 'components/common/DateTimeInput.vue';
+import { logger } from 'src/boot/logger';
 
 export default defineComponent({
 	name: 'HomeworkDates',
@@ -59,21 +59,39 @@ export default defineComponent({
 	emits: ['updateDates'],
 	setup(props, { emit }) {
 		const hw_dates = ref<HomeworkSetDates>(props.dates.clone());
-		if (!hw_dates.value.reduced_scoring) {
-			hw_dates.value.reduced_scoring = hw_dates.value.due;
-		}
+		const error_message = ref<string>('');
 
-		watch(() => hw_dates.value, () => {
-			emit('updateDates', hw_dates.value);
+		watch(() => props.dates, (new_dates, old_dates) => {
+			logger.debug('[HomeworkDates] parent has changed the homework set dates.');
+			logger.debug(`---old: ${JSON.stringify(old_dates)}`);
+			logger.debug(`---new: ${JSON.stringify(new_dates)}`);
+			hw_dates.value = props.dates.clone();
+		});
+
+		watch(() => hw_dates.value, (new_dates, old_dates) => {
+			logger.debug('[HomeworkDates] detected mutation in hw_dates...');
+
+			// avoid reactive loop
+			if (!props.reduced_scoring && hw_dates.value.reduced_scoring !== hw_dates.value.due) {
+				hw_dates.value.reduced_scoring = hw_dates.value.due;
+			}
+
+			const dates_are_valid = hw_dates.value.isValid({ enable_reduced_scoring: props.reduced_scoring });
+			const is_updated = JSON.stringify(old_dates) !== JSON.stringify(new_dates);
+			if (dates_are_valid && is_updated) {
+				logger.debug('[HomeworkDates] mutation confirmed + dates are valid -> telling parent.');
+				error_message.value = '';
+				emit('updateDates', hw_dates.value);
+			} else {
+				if (!dates_are_valid) error_message.value = 'Dates must be in order.';
+				logger.debug(error_message.value || 'Nothing changed. We must be changing between hw sets...');
+			};
 		}, { deep: true });
 
 		return {
 			hw_dates,
 			enable_reduced_scoring: computed(() => props.reduced_scoring),
-			checkDates: [
-				// Not sure why need to cast this?
-				() => checkHWDates(hw_dates.value as HomeworkSetDates, props.reduced_scoring)
-			]
+			error_message,
 		};
 	}
 

--- a/src/components/instructor/SetDetails/HomeworkSet.vue
+++ b/src/components/instructor/SetDetails/HomeworkSet.vue
@@ -70,17 +70,11 @@ export default defineComponent({
 		watch(() => props.set, (new_set, old_set) => {
 			logger.debug(`[HomeworkSet] parent changed homework set from: ${old_set.set_name} to ${new_set.set_name}`);
 			homework_set.value = props.set.clone();
-		}, { deep: true });
+		});
 
-		watch(() => homework_set.value, (new_set, old_set) => {
+		watch(() => homework_set.value, () => {
 			logger.debug('[HomeworkSet] detected mutation in homework_set...');
-			if (old_set.set_id === new_set.set_id && JSON.stringify(new_set) !== JSON.stringify(old_set)) {
-				logger.debug(`[HomeworkSet] mutation has occurred, updating ${homework_set.value.set_name}.`);
-				emit('updateSet', homework_set.value);
-			} else {
-				logger.debug(`[HomeworkSet] nevermind, still getting from ${old_set.set_name} to ${new_set.set_name}.`);
-				if (JSON.stringify(new_set) === JSON.stringify(old_set)) logger.debug('[HomeworkSet] again?');
-			}
+			emit('updateSet', homework_set.value);
 		},
 		{ deep: true });
 

--- a/src/components/instructor/SetDetails/HomeworkSet.vue
+++ b/src/components/instructor/SetDetails/HomeworkSet.vue
@@ -39,6 +39,7 @@ import HomeworkDates from './HomeworkDates.vue';
 import InputWithBlur from 'src/components/common/InputWithBlur.vue';
 import { HomeworkSet, HomeworkSetDates } from 'src/common/models/problem_sets';
 import { problem_set_type_options } from 'src/common/views';
+import { logger } from 'src/boot/logger';
 
 export default defineComponent({
 	components: {
@@ -66,13 +67,19 @@ export default defineComponent({
 			set_type.value = props.reset_set_type;
 		});
 
-		watch(() => props.set, () => {
+		watch(() => props.set, (new_set, old_set) => {
+			logger.debug(`[HomeworkSet] parent changed homework set from: ${old_set.set_name} to ${new_set.set_name}`);
 			homework_set.value = props.set.clone();
 		}, { deep: true });
 
-		watch(() => homework_set.value.clone(), (new_set, old_set) => {
-			if (JSON.stringify(new_set) !== JSON.stringify(old_set)) {
+		watch(() => homework_set.value, (new_set, old_set) => {
+			logger.debug('[HomeworkSet] detected mutation in homework_set...');
+			if (old_set.set_id === new_set.set_id && JSON.stringify(new_set) !== JSON.stringify(old_set)) {
+				logger.debug(`[HomeworkSet] mutation has occurred, updating ${homework_set.value.set_name}.`);
 				emit('updateSet', homework_set.value);
+			} else {
+				logger.debug(`[HomeworkSet] nevermind, still getting from ${old_set.set_name} to ${new_set.set_name}.`);
+				if (JSON.stringify(new_set) === JSON.stringify(old_set)) logger.debug('[HomeworkSet] again?');
 			}
 		},
 		{ deep: true });
@@ -82,6 +89,7 @@ export default defineComponent({
 			set_options: problem_set_type_options,
 			homework_set,
 			updateDates: (dates: HomeworkSetDates) => {
+				logger.debug('[HomeworkSet/updateDates] setting dates on homework_set.');
 				homework_set.value.set_dates.set(dates.toObject());
 			}
 		};

--- a/src/components/instructor/SetDetails/Quiz.vue
+++ b/src/components/instructor/SetDetails/Quiz.vue
@@ -73,17 +73,11 @@ export default defineComponent({
 		watch(() => props.set, (new_set, old_set) => {
 			logger.debug(`[Quiz] parent changed homework set from: ${old_set.set_name} to ${new_set.set_name}`);
 			quiz.value = props.set.clone();
-		}, { deep: true });
+		});
 
-		watch(() => quiz.value, (new_set, old_set) => {
+		watch(() => quiz.value, () => {
 			logger.debug('[Quiz] detected mutation in homework_set...');
-			if (old_set.set_id === new_set.set_id && JSON.stringify(new_set) !== JSON.stringify(old_set)) {
-				logger.debug(`[Quiz] mutation has occurred, updating ${quiz.value.set_name}.`);
-				emit('updateSet', quiz.value);
-			} else {
-				logger.debug(`[Quiz] nevermind, still getting from ${old_set.set_name} to ${new_set.set_name}.`);
-				if (JSON.stringify(new_set) === JSON.stringify(old_set)) logger.debug('[Quiz] again?');
-			}
+			emit('updateSet', quiz.value);
 		},
 		{ deep: true });
 

--- a/src/components/instructor/SetDetails/QuizDates.vue
+++ b/src/components/instructor/SetDetails/QuizDates.vue
@@ -5,7 +5,7 @@
 		<td>
 			<date-time-input
 				v-model="quiz_dates.open"
-				:validation="checkDates"
+				:errorMessage="error_message"
 			/></td>
 	</tr>
 	<tr>
@@ -13,7 +13,7 @@
 		<td>
 			<date-time-input
 				v-model="quiz_dates.due"
-				:validation="checkDates"
+				:errorMessage="error_message"
 			/></td>
 	</tr>
 	<tr>
@@ -21,7 +21,7 @@
 		<td>
 			<date-time-input
 				v-model="quiz_dates.answer"
-				:validation="checkDates"
+				:errorMessage="error_message"
 			/></td>
 	</tr>
 </template>
@@ -29,9 +29,9 @@
 <script lang="ts">
 import { defineComponent, ref, watch } from 'vue';
 import type { PropType } from 'vue';
-import { checkQuizDates } from 'src/common/views';
 import { QuizDates } from 'src/common/models/problem_sets';
 import DateTimeInput from 'src/components/common/DateTimeInput.vue';
+import { logger } from 'src/boot/logger';
 
 export default defineComponent({
 	name: 'QuizDates',
@@ -47,14 +47,33 @@ export default defineComponent({
 	emits: ['updateDates'],
 	setup(props, { emit }) {
 		const quiz_dates = ref<QuizDates>(props.dates.clone());
+		const error_message = ref<string>('');
 
-		watch(() => quiz_dates.value, () => {
-			emit('updateDates', quiz_dates.value);
+		watch(() => props.dates, (new_dates, old_dates) => {
+			logger.debug('[QuizDates] parent has changed the quiz set.');
+			logger.debug(`---old: ${JSON.stringify(old_dates)}`);
+			logger.debug(`---new: ${JSON.stringify(new_dates)}`);
+			quiz_dates.value = props.dates.clone();
+		});
+
+		watch(() => quiz_dates.value, (new_dates, old_dates) => {
+			logger.debug('[QuizDates] detected mutation in quiz_dates...');
+
+			const dates_are_valid = quiz_dates.value.isValid();
+			const is_updated = JSON.stringify(old_dates) !== JSON.stringify(new_dates);
+			if (dates_are_valid && is_updated) {
+				logger.debug('[QuizDates] mutation confirmed + dates are valid -> telling parent.');
+				error_message.value = '';
+				emit('updateDates', quiz_dates.value);
+			} else {
+				if (!dates_are_valid) error_message.value = 'Dates must be in order.';
+				logger.debug(error_message.value || 'Nothing changed. We must be changing between quiz sets...');
+			};
 		}, { deep: true });
 
 		return {
 			quiz_dates,
-			checkDates: [() => checkQuizDates(quiz_dates.value as QuizDates)]
+			error_message,
 		};
 	}
 

--- a/src/components/instructor/SetDetails/QuizDates.vue
+++ b/src/components/instructor/SetDetails/QuizDates.vue
@@ -51,23 +51,23 @@ export default defineComponent({
 
 		watch(() => props.dates, (new_dates, old_dates) => {
 			logger.debug('[QuizDates] parent has changed the quiz set.');
-			logger.debug(`---old: ${JSON.stringify(old_dates)}`);
-			logger.debug(`---new: ${JSON.stringify(new_dates)}`);
-			quiz_dates.value = props.dates.clone();
+			if (JSON.stringify(old_dates) === JSON.stringify(new_dates)) {
+				logger.debug('--- nevermind, this is fallout from the changes we just reported.');
+			} else {
+				quiz_dates.value = props.dates.clone();
+			}
 		});
 
-		watch(() => quiz_dates.value, (new_dates, old_dates) => {
+		watch(() => quiz_dates.value, () => {
 			logger.debug('[QuizDates] detected mutation in quiz_dates...');
 
-			const dates_are_valid = quiz_dates.value.isValid();
-			const is_updated = JSON.stringify(old_dates) !== JSON.stringify(new_dates);
-			if (dates_are_valid && is_updated) {
-				logger.debug('[QuizDates] mutation confirmed + dates are valid -> telling parent.');
+			if (quiz_dates.value.isValid()) {
+				logger.debug('[QuizDates] dates are valid -> telling parent & clearing error message.');
 				error_message.value = '';
 				emit('updateDates', quiz_dates.value);
 			} else {
-				if (!dates_are_valid) error_message.value = 'Dates must be in order.';
-				logger.debug(error_message.value || 'Nothing changed. We must be changing between quiz sets...');
+				error_message.value = 'Dates must be in order.';
+				logger.debug(error_message.value);
 			};
 		}, { deep: true });
 

--- a/src/components/instructor/SetDetails/ReviewSet.vue
+++ b/src/components/instructor/SetDetails/ReviewSet.vue
@@ -64,17 +64,11 @@ export default defineComponent({
 		watch(() => props.set, (new_set, old_set) => {
 			logger.debug(`[HomeworkSet] parent changed homework set from: ${old_set.set_name} to ${new_set.set_name}`);
 			review_set.value = props.set.clone();
-		}, { deep: true });
+		});
 
-		watch(() => review_set.value, (new_set, old_set) => {
+		watch(() => review_set.value, () => {
 			logger.debug('[HomeworkSet] detected mutation in homework_set...');
-			if (old_set.set_id === new_set.set_id && JSON.stringify(new_set) !== JSON.stringify(old_set)) {
-				logger.debug(`[HomeworkSet] mutation has occurred, updating ${review_set.value.set_name}.`);
-				emit('updateSet', review_set.value);
-			} else {
-				logger.debug(`[HomeworkSet] nevermind, still getting from ${old_set.set_name} to ${new_set.set_name}.`);
-				if (JSON.stringify(new_set) === JSON.stringify(old_set)) logger.debug('[HomeworkSet] again?');
-			}
+			emit('updateSet', review_set.value);
 		},
 		{ deep: true });
 

--- a/src/components/instructor/SetDetails/ReviewSet.vue
+++ b/src/components/instructor/SetDetails/ReviewSet.vue
@@ -33,6 +33,7 @@ import ReviewSetDatesInput from './ReviewSetDates.vue';
 import InputWithBlur from 'src/components/common/InputWithBlur.vue';
 import { ReviewSet, ReviewSetDates } from 'src/common/models/problem_sets';
 import { problem_set_type_options } from 'src/common/views';
+import { logger } from 'src/boot/logger';
 
 export default defineComponent({
 	components: {
@@ -60,13 +61,19 @@ export default defineComponent({
 			set_type.value = props.reset_set_type;
 		});
 
-		watch(() => props.set, () => {
+		watch(() => props.set, (new_set, old_set) => {
+			logger.debug(`[HomeworkSet] parent changed homework set from: ${old_set.set_name} to ${new_set.set_name}`);
 			review_set.value = props.set.clone();
 		}, { deep: true });
 
-		watch(() => review_set.value.clone(), (new_set, old_set) => {
-			if (JSON.stringify(new_set) !== JSON.stringify(old_set)) {
+		watch(() => review_set.value, (new_set, old_set) => {
+			logger.debug('[HomeworkSet] detected mutation in homework_set...');
+			if (old_set.set_id === new_set.set_id && JSON.stringify(new_set) !== JSON.stringify(old_set)) {
+				logger.debug(`[HomeworkSet] mutation has occurred, updating ${review_set.value.set_name}.`);
 				emit('updateSet', review_set.value);
+			} else {
+				logger.debug(`[HomeworkSet] nevermind, still getting from ${old_set.set_name} to ${new_set.set_name}.`);
+				if (JSON.stringify(new_set) === JSON.stringify(old_set)) logger.debug('[HomeworkSet] again?');
 			}
 		},
 		{ deep: true });
@@ -76,6 +83,7 @@ export default defineComponent({
 			set_options: problem_set_type_options,
 			review_set,
 			updateDates: (dates: ReviewSetDates) => {
+				logger.debug('[ReviewSet/updateDates] setting dates on review_set.');
 				review_set.value.set_dates.set(dates.toObject());
 			},
 		};

--- a/src/components/instructor/SetDetails/ReviewSetDates.vue
+++ b/src/components/instructor/SetDetails/ReviewSetDates.vue
@@ -4,8 +4,8 @@
 		<td class="header">Open Date</td>
 		<td>
 			<date-time-input
-				v-model="review_set_dates.open"
-				:validation="checkDates"
+				v-model="review_dates.open"
+				:errorMessage="error_message"
 			/>
 		</td>
 	</tr>
@@ -13,8 +13,8 @@
 		<td class="header">Closed Date</td>
 		<td>
 			<date-time-input
-				v-model="review_set_dates.closed"
-				:validation="checkDates"
+				v-model="review_dates.closed"
+				:errorMessage="error_message"
 			/>
 		</td>
 	</tr>
@@ -23,9 +23,9 @@
 <script lang="ts">
 import { defineComponent, ref, watch } from 'vue';
 import type { PropType } from 'vue';
-import { checkReviewSetDates } from 'src/common/views';
 import { ReviewSetDates } from 'src/common/models/problem_sets';
 import DateTimeInput from 'components/common/DateTimeInput.vue';
+import { logger } from 'src/boot/logger';
 
 export default defineComponent({
 	name: 'ReviewSetDates',
@@ -40,17 +40,34 @@ export default defineComponent({
 	},
 	emits: ['updateDates'],
 	setup(props, { emit }) {
-		const review_set_dates = ref<ReviewSetDates>(props.dates.clone());
+		const review_dates = ref<ReviewSetDates>(props.dates.clone());
+		const error_message = ref<string>('');
 
-		watch(() => review_set_dates.value, () => {
-			emit('updateDates', review_set_dates.value);
+		watch(() => props.dates, (new_dates, old_dates) => {
+			logger.debug('[ReviewDates] parent has changed the review set.');
+			logger.debug(`---old: ${JSON.stringify(old_dates)}`);
+			logger.debug(`---new: ${JSON.stringify(new_dates)}`);
+			review_dates.value = props.dates.clone();
+		});
+
+		watch(() => review_dates.value, (new_dates, old_dates) => {
+			logger.debug('[ReviewDates] detected mutation in review_dates...');
+
+			const dates_are_valid = review_dates.value.isValid();
+			const is_updated = JSON.stringify(old_dates) !== JSON.stringify(new_dates);
+			if (dates_are_valid && is_updated) {
+				logger.debug('[ReviewDates] mutation confirmed + dates are valid -> telling parent.');
+				error_message.value = '';
+				emit('updateDates', review_dates.value);
+			} else {
+				if (!dates_are_valid) error_message.value = 'Dates must be in order.';
+				logger.debug(error_message.value || 'Nothing changed. We must be changing between review sets...');
+			};
 		}, { deep: true });
 
 		return {
-			review_set_dates,
-			checkDates: [
-				() => checkReviewSetDates(review_set_dates.value as ReviewSetDates)
-			]
+			review_dates,
+			error_message,
 		};
 	}
 

--- a/src/components/instructor/SetDetails/ReviewSetDates.vue
+++ b/src/components/instructor/SetDetails/ReviewSetDates.vue
@@ -45,23 +45,23 @@ export default defineComponent({
 
 		watch(() => props.dates, (new_dates, old_dates) => {
 			logger.debug('[ReviewDates] parent has changed the review set.');
-			logger.debug(`---old: ${JSON.stringify(old_dates)}`);
-			logger.debug(`---new: ${JSON.stringify(new_dates)}`);
-			review_dates.value = props.dates.clone();
+			if (JSON.stringify(old_dates) === JSON.stringify(new_dates)) {
+				logger.debug('--- nevermind, this is fallout from the changes we just reported.');
+			} else {
+				review_dates.value = props.dates.clone();
+			}
 		});
 
-		watch(() => review_dates.value, (new_dates, old_dates) => {
+		watch(() => review_dates.value, () => {
 			logger.debug('[ReviewDates] detected mutation in review_dates...');
 
-			const dates_are_valid = review_dates.value.isValid();
-			const is_updated = JSON.stringify(old_dates) !== JSON.stringify(new_dates);
-			if (dates_are_valid && is_updated) {
-				logger.debug('[ReviewDates] mutation confirmed + dates are valid -> telling parent.');
+			if (review_dates.value.isValid()) {
+				logger.debug('[ReviewDates] dates are valid -> telling parent & clearing error message.');
 				error_message.value = '';
 				emit('updateDates', review_dates.value);
 			} else {
-				if (!dates_are_valid) error_message.value = 'Dates must be in order.';
-				logger.debug(error_message.value || 'Nothing changed. We must be changing between review sets...');
+				error_message.value = 'Dates must be in order.';
+				logger.debug(error_message.value);
 			};
 		}, { deep: true });
 

--- a/src/pages/instructor/ProblemSetDetails.vue
+++ b/src/pages/instructor/ProblemSetDetails.vue
@@ -5,23 +5,23 @@
 			:reset_set_type="reset_set_type"
 			@update-set="updateSet"
 			@change-set-type="requestChangeSetType"
-			v-if="problem_set.set_type==='HW'" />
+			v-if="problem_set?.set_type==='HW'" />
 		<quiz-view
 			:set="problem_set"
 			@update-set="updateSet"
 			@change-set-type="requestChangeSetType"
-			v-else-if="problem_set.set_type==='QUIZ'" />
+			v-else-if="problem_set?.set_type==='QUIZ'" />
 		<review-set-view
 			:set="problem_set"
 			@update-set="updateSet"
 			@change-set-type="requestChangeSetType"
-			v-else-if="problem_set.set_type==='REVIEW'" />
+			v-else-if="problem_set?.set_type==='REVIEW'" />
 	</q-page>
 	<q-dialog v-model="change_set_type_dialog" persistent>
 		<q-card>
 			<q-card-section class="row items-center">
 				<span class="q-ml-sm">You have requested that this set be converted from a
-					{{ problem_set.set_type }} to a {{ new_set_type.label }}.  You may lose
+					{{ problem_set?.set_type }} to a {{ new_set_type.label }}.  You may lose
 					information that the old set has that the new set does not have capabilities
 					of. Please select "Ok" or "Cancel".
 				</span>
@@ -43,7 +43,7 @@ import { logger } from 'boot/logger';
 
 import { useProblemSetStore } from 'src/stores/problem_sets';
 import { parseRouteSetID } from 'src/router/utils';
-import { ProblemSet, HomeworkSet, ReviewSet, Quiz } from 'src/common/models/problem_sets';
+import { ProblemSet, ProblemSetType, convertSet } from 'src/common/models/problem_sets';
 import HomeworkSetView from 'src/components/instructor/SetDetails/HomeworkSet.vue';
 import QuizView from 'src/components/instructor/SetDetails/Quiz.vue';
 import ReviewSetView from 'src/components/instructor/SetDetails/ReviewSet.vue';
@@ -61,17 +61,17 @@ export default defineComponent({
 		const $q = useQuasar();
 
 		const change_set_type_dialog = ref<boolean>(false);
-		const new_set_type = ref<{value?: string, label?: string}>({});
+		const new_set_type = ref<{value?: ProblemSetType, label?: string}>({});
 		// Used to reset the set type in the children views if the set type change is cancelled.
 		// This seems like overkill--perhaps a better way.
 		const reset_set_type = ref<string>('');
 		const set_id = computed(() => parseRouteSetID(route));
 		const problem_set = computed(() => problem_sets.problem_sets
-			.find((_set) => _set.set_id === set_id.value) ?? new ProblemSet());
+			.find((_set) => _set.set_id === set_id.value));
 
 		const updateSet = (set: ProblemSet) => {
 			// if the entire set just changed, don't update.
-			if (problem_set.value.set_id === set.set_id) {
+			if (problem_set.value && problem_set.value.set_id === set.set_id) {
 				void problem_sets.updateSet(set);
 				const msg = `The problem set '${set.set_name}' was successfully updated.`;
 				logger.debug(`[ProblemSetDetails]: ${msg}`);
@@ -82,6 +82,29 @@ export default defineComponent({
 			}
 		};
 
+		const requestChangeSetType = (set_type: {value: ProblemSetType, label: string}) => {
+			logger.debug('ProblemSetDetails: Requesting a set type change');
+			change_set_type_dialog.value = true;
+			new_set_type.value = set_type;
+			// This is needed if the set type change is cancelled.
+			reset_set_type.value = '';
+		};
+
+		const cancelChangeSetType = () => {
+			// If the set type change is cancelled, reset the set type in any child of this.
+			if (problem_set.value) reset_set_type.value = problem_set.value.set_type;
+		};
+
+		const changeSetType = () => {
+			logger.debug('[ProblemSetDetails/changeSetType]');
+			if (problem_set.value && new_set_type.value.value) {
+				const updated_set = convertSet((problem_set.value as ProblemSet), new_set_type.value.value);
+				updateSet(updated_set);
+			} else {
+				logger.error('[changeSetType] missing either problem_set or new_set_type?! TSNH');
+			}
+		};
+
 		return {
 			set_id,
 			problem_set,
@@ -89,75 +112,9 @@ export default defineComponent({
 			new_set_type,
 			reset_set_type,
 			updateSet,
-			requestChangeSetType: (set_type: {value: string, label: string}) => {
-				change_set_type_dialog.value = true;
-				new_set_type.value = set_type;
-				// This is needed if the set type change is cancelled.
-				reset_set_type.value = '';
-				logger.debug('ProblemSetDetails: Requesting a set type change');
-			},
-			cancelChangeSetType: () => {
-				// If the set type change is cancel, reset the set type in any child of this.
-				reset_set_type.value = problem_set.value.set_type;
-			},
-			// Change the type of the set.  Since the set_params don't really overlap (right now)
-			// this is just adjusting dates.
-			changeSetType: () => {
-				logger.debug('[ProblemSetDetails/changeSetType]');
-				const problem_set_params = problem_set.value.toObject();
-				delete problem_set_params.set_params;
-				delete problem_set_params.set_dates;
-
-				// Try to best keep the dates consistent.
-				if (new_set_type.value.value === 'QUIZ') {
-					const new_quiz = new Quiz(problem_set_params);
-					if (problem_set.value instanceof HomeworkSet) {
-						new_quiz.set_dates.set({
-							open: problem_set.value.set_dates.open,
-							due: problem_set.value.set_dates.due,
-							answer: problem_set.value.set_dates.answer
-						});
-					} else if (problem_set.value instanceof ReviewSet) {
-						new_quiz.set_dates.set({
-							open: problem_set.value.set_dates.open,
-							due: problem_set.value.set_dates.closed,
-							answer: problem_set.value.set_dates.closed
-						});
-					}
-					updateSet(new_quiz);
-				} else if (new_set_type.value.value === 'REVIEW') {
-					const new_review_set = new ReviewSet(problem_set_params);
-					if (problem_set.value instanceof HomeworkSet || problem_set.value instanceof Quiz) {
-						new_review_set.set_dates.set({
-							open: problem_set.value.set_dates.open,
-							closed: problem_set.value.set_dates.due,
-						});
-					}
-					updateSet(new_review_set);
-				} else if (new_set_type.value.value === 'HW') {
-					const new_hw_set = new HomeworkSet(problem_set_params);
-					if (problem_set.value instanceof ReviewSet) {
-						new_hw_set.set_dates.set({
-							open: problem_set.value.set_dates.open,
-							reduced_scoring: problem_set.value.set_dates.closed,
-							due: problem_set.value.set_dates.closed,
-							answer: problem_set.value.set_dates.closed
-						});
-					} else if (problem_set.value instanceof Quiz) {
-						new_hw_set.set_dates.set({
-							open: problem_set.value.set_dates.open,
-							reduced_scoring: problem_set.value.set_dates.due,
-							due: problem_set.value.set_dates.due,
-							answer: problem_set.value.set_dates.answer
-						});
-					}
-					updateSet(new_hw_set);
-				} else {
-					logger.debug('ProblemSetDetails: oops, set type ' +
-						`${new_set_type.value.value ?? 'UNKNOWN'} not defined.`);
-				}
-
-			}
+			requestChangeSetType,
+			cancelChangeSetType,
+			changeSetType
 		};
 	}
 });

--- a/src/pages/instructor/ProblemSetDetails.vue
+++ b/src/pages/instructor/ProblemSetDetails.vue
@@ -69,15 +69,14 @@ export default defineComponent({
 		const problem_set = computed(() => problem_sets.problem_sets
 			.find((_set) => _set.set_id === set_id.value));
 
-		const updateSet = (set: ProblemSet) => {
+		const updateSet = async (set: ProblemSet) => {
 			// if the entire set just changed, don't update.
 			if (problem_set.value && problem_set.value.set_id === set.set_id) {
-				void problem_sets.updateSet(set);
-				const msg = `The problem set '${set.set_name}' was successfully updated.`;
-				logger.debug(`[ProblemSetDetails]: ${msg}`);
+				const { error, message } = await problem_sets.updateSet(set);
+				logger.debug(`[ProblemSetDetails/updateSet]: ${message}`);
 				$q.notify({
-					message: msg,
-					color: 'green'
+					message: message,
+					color: error ? 'red' : 'green'
 				});
 			}
 		};

--- a/src/pages/instructor/ProblemSetDetails.vue
+++ b/src/pages/instructor/ProblemSetDetails.vue
@@ -69,7 +69,7 @@ export default defineComponent({
 		const problem_set = computed(() => problem_sets.problem_sets
 			.find((_set) => _set.set_id === set_id.value) ?? new ProblemSet());
 
-		const updateSet =  (set: ProblemSet) => {
+		const updateSet = (set: ProblemSet) => {
 			// if the entire set just changed, don't update.
 			if (problem_set.value.set_id === set.set_id) {
 				void problem_sets.updateSet(set);
@@ -103,6 +103,7 @@ export default defineComponent({
 			// Change the type of the set.  Since the set_params don't really overlap (right now)
 			// this is just adjusting dates.
 			changeSetType: () => {
+				logger.debug('[ProblemSetDetails/changeSetType]');
 				const problem_set_params = problem_set.value.toObject();
 				delete problem_set_params.set_params;
 				delete problem_set_params.set_dates;
@@ -154,7 +155,6 @@ export default defineComponent({
 				} else {
 					logger.debug('ProblemSetDetails: oops, set type ' +
 						`${new_set_type.value.value ?? 'UNKNOWN'} not defined.`);
-					return;
 				}
 
 			}


### PR DESCRIPTION
Resolved: 
- dates update when changing between sets of the same type
- no green update when switching between sets
- putting the dates out of order causes an error message on all date fields
- fixing the date order removes the error message and calls the API to update the set (no more 'save' and 'cancel')

I left in a lot of `logger.debug` statements... I personally think they help to give an idea of the reactivity of various components. 

Short story long: if you have one-way communication from parent to child, use `compute`; and if you need two-way communication, use a `ref` with a watcher on the incoming prop *and* a watcher on the ref's `.value` to emit the update event and pass the value back to the parent. Of course, when the parent catches the update it must check to see if there's been an actual mutation of the object (and update it) or if we're seeing the result of a component switching over to a new object (and ignore it).