### PR TITLE
Fix the language selector in the user settings dropdown.

### DIFF
--- a/lib/DB/Schema/ResultSet/User.pm
+++ b/lib/DB/Schema/ResultSet/User.pm
@@ -299,8 +299,8 @@ An hashref of the user or merged user or a C<DBIx::Class::ResultSet>
 =cut
 
 sub getCourseUser ($self, %args) {
-
 	my $course_user;
+
 	if (defined($args{info}->{course_user_id})) {
 		$course_user = $self->rs("CourseUser")->find({
 			course_user_id => $args{info}->{course_user_id}
@@ -310,9 +310,8 @@ sub getCourseUser ($self, %args) {
 		my $user   = $self->getGlobalUser(info => getUserInfo($args{info}), as_result_set => 1);
 		$course_user = $self->rs("CourseUser")->find({ course_id => $course->course_id, user_id => $user->user_id });
 		DB::Exception::UserNotInCourse->throw(
-			message => "The user ${\$user->username} is not enrolled in the course ${\$course->course_name}"
-		) unless defined $course_user || $args{skip_throw};
-
+			message => "The user ${\$user->username} is not enrolled in the course ${\$course->course_name}")
+			unless defined $course_user || $args{skip_throw};
 	}
 
 	return $course_user if $args{as_result_set};

--- a/src/layouts/MenuBar.vue
+++ b/src/layouts/MenuBar.vue
@@ -69,6 +69,7 @@ import { useI18n } from 'vue-i18n';
 import { setI18nLanguage } from 'boot/i18n';
 import { useSessionStore } from 'src/stores/session';
 import { useUserStore } from 'src/stores/users';
+import type { CourseSettingInfo } from 'src/common/models/settings';
 import { useSettingsStore } from 'src/stores/settings';
 
 export default defineComponent({
@@ -103,9 +104,9 @@ export default defineComponent({
 				void session.setCourse({ course_name, course_id });
 			},
 			currentLocale,
-			availableLocales: computed(() => {
-				return settings.getCourseSetting('languages').value as string[];
-			}),
+			availableLocales: computed(() =>
+				settings.default_settings.find((setting: CourseSettingInfo) => setting.var === 'language')?.options
+			),
 			setI18nLanguage,
 			open_user_settings: ref(false),
 			current_view,


### PR DESCRIPTION
This fixes another regression in the vuex-to-pinia pull request.  There is no "languages" setting, there is only a "language" setting, and it is not the "value" of that setting that is needed for the available locales, but the options for that setting.