### PR TITLE
avoid created hook & conditionally load data

### DIFF
--- a/src/pages/instructor/Instructor.vue
+++ b/src/pages/instructor/Instructor.vue
@@ -23,43 +23,27 @@ export default defineComponent({
 	setup() {
 		const session = useSessionStore();
 		const users = useUserStore();
-		const route = useRoute();
+		const settings = useSettingsStore();
+		const problem_sets = useProblemSetStore();
 
+		const route = useRoute();
 		const course_id = parseRouteCourseID(route);
 		const course = users.user_courses.find(c => c.course_id === course_id);
+
 		if (course) {
 			void session.setCourse({
 				course_id,
 				course_name: course.course_name
 			});
+			void users.fetchMergedUsers(course_id);
+			void problem_sets.fetchProblemSets(course_id);
+			void settings.fetchDefaultSettings()
+				.then(() => settings.fetchCourseSettings(course_id))
+				.then(() => setI18nLanguage(settings.getCourseSetting('language').value as string))
+				.catch((err) => logger.error(err));
+		} else {
+			logger.error(`[Instructor] Do you even GO here? Course #${course_id} not associated with your user.`);
 		}
-	},
-	created() {
-		// fetch most data needed for instructor views
-		const users = useUserStore();
-		const settings = useSettingsStore();
-		const problem_sets = useProblemSetStore();
-		const route = useRoute();
-
-		const course_id = parseRouteCourseID(route);
-
-		logger.debug('[Intructor]: fetching users from the server.');
-		void users.fetchMergedUsers(course_id);
-
-		logger.debug('[Instructor]: fetch problem_sets from server');
-		void problem_sets.fetchProblemSets(course_id);
-
-		logger.debug('[Intructor]: fetch settings from the server.');
-		settings.fetchDefaultSettings().then(() => {
-			settings.fetchCourseSettings(course_id).then(() => {
-				// Set the language from the course settings.
-				void setI18nLanguage(settings.getCourseSetting('language').value as string);
-			}).catch((err) => {
-				logger.error(err);
-			});
-		}).catch((err) => {
-			logger.error(err);
-		});
 
 	}
 });

--- a/src/router/utils.ts
+++ b/src/router/utils.ts
@@ -2,7 +2,7 @@
  * This has some basic routing functions
  */
 
-import { RouteLocationNormalizedLoaded } from 'vue-router';
+import type { RouteLocationNormalizedLoaded } from 'vue-router';
 
 export const parseRouteSetID = (route: RouteLocationNormalizedLoaded) => {
 	return Array.isArray(route.params.set_id)


### PR DESCRIPTION
No need to nest the `.then()`, just chain them together.

Also, move data loading out of `created` and put it in `setup` (consistent use of composition API). This way, we only load the data if the course belongs to the requesting user -- we *should* catch this sooner and provide an error message (but that can wait for our authentication sprint).