### PR TITLE
Rename models

### DIFF
--- a/lib/WeBWorK3/Hooks.pm
+++ b/lib/WeBWorK3/Hooks.pm
@@ -43,7 +43,7 @@ our $check_permission = sub ($next, $c, $action, $) {
 	return $next->() if $c->req->url->to_string =~ /\/api\/login/x;
 
 	if (!$c->is_user_authenticated) {
-		$c->render(json => { has_permission => 0, msg => 'permission error' }, status => 401); # unauthenticated
+		$c->render(json => { has_permission => 0, msg => 'permission error' }, status => 401);
 		return;
 	}
 
@@ -55,7 +55,7 @@ our $check_permission = sub ($next, $c, $action, $) {
 		my $course_user = $user_obj->course_users->find({ course_id => $c->param('course_id') });
 
 		if (!$course_user) {
-			$c->render(json => { has_permission => 0, msg => 'permission error' }, status => 406); # not acceptable
+			$c->render(json => { has_permission => 0, msg => 'permission error' }, status => 406);
 			return;
 		}
 
@@ -66,7 +66,7 @@ our $check_permission = sub ($next, $c, $action, $) {
 		if (has_permission($user, $c->perm_table->{ $c->{stash}{controller} }{ $c->{stash}{action} })) {
 			return $next->();
 		} else {
-			$c->render(json => { has_permission => 0, msg => 'permission error' }, status => 403); # forbidden
+			$c->render(json => { has_permission => 0, msg => 'permission error' }, status => 403);
 		}
 	} else {
 		$next->();

--- a/lib/WeBWorK3/Hooks.pm
+++ b/lib/WeBWorK3/Hooks.pm
@@ -43,7 +43,7 @@ our $check_permission = sub ($next, $c, $action, $) {
 	return $next->() if $c->req->url->to_string =~ /\/api\/login/x;
 
 	if (!$c->is_user_authenticated) {
-		$c->render(json => { has_permission => 0, msg => 'permission error' });
+		$c->render(json => { has_permission => 0, msg => 'permission error' }, status => 401); # unauthenticated
 		return;
 	}
 
@@ -55,7 +55,7 @@ our $check_permission = sub ($next, $c, $action, $) {
 		my $course_user = $user_obj->course_users->find({ course_id => $c->param('course_id') });
 
 		if (!$course_user) {
-			$c->render(json => { has_permission => 0, msg => 'permission error' });
+			$c->render(json => { has_permission => 0, msg => 'permission error' }, status => 406); # not acceptable
 			return;
 		}
 
@@ -66,7 +66,7 @@ our $check_permission = sub ($next, $c, $action, $) {
 		if (has_permission($user, $c->perm_table->{ $c->{stash}{controller} }{ $c->{stash}{action} })) {
 			return $next->();
 		} else {
-			$c->render(json => { has_permission => 0, msg => 'permission error' });
+			$c->render(json => { has_permission => 0, msg => 'permission error' }, status => 403); # forbidden
 		}
 	} else {
 		$next->();

--- a/src/common/models/courses.ts
+++ b/src/common/models/courses.ts
@@ -137,8 +137,8 @@ export class UserCourse extends Model {
 		if (params.course_name == undefined) {
 			throw new RequiredFieldsException('course_name');
 		}
-		if (params.username == undefined) {
-			throw new RequiredFieldsException('username');
+		if (params.user_id == undefined) {
+			throw new RequiredFieldsException('user_id');
 		}
 		this.set(params);
 	}

--- a/src/components/common/UserCourses.vue
+++ b/src/components/common/UserCourses.vue
@@ -64,8 +64,9 @@ import { parseNonNegInt, parseUserRole } from 'src/common/models/parsers';
 
 export default defineComponent({
 	name: 'UserCourses',
-	setup() {
+	async setup() {
 		const session = useSessionStore();
+		await session.fetchUserCourses(parseNonNegInt(session.user.user_id));
 		return {
 			student_courses: computed(() =>
 				session.user_courses.filter(user_course => parseUserRole(user_course.role) === 'STUDENT')
@@ -76,11 +77,5 @@ export default defineComponent({
 			user: computed(() => session.user)
 		};
 	},
-	created() {
-		// fetch the data when the view is created and the data is
-		// already being observed
-		const session = useSessionStore();
-		void session.fetchUserCourses(parseNonNegInt(session.user.user_id ?? 0));
-	}
 });
 </script>

--- a/src/stores/session.ts
+++ b/src/stores/session.ts
@@ -2,7 +2,7 @@
 
 import { defineStore } from 'pinia';
 import { api } from 'boot/axios';
-import { ParseableUser, User } from 'src/common/models/users';
+import { User } from 'src/common/models/users';
 import type { SessionInfo } from 'src/common/models/session';
 import { ParseableUserCourse, UserCourse } from 'src/common/models/courses';
 import { logger } from 'boot/logger';
@@ -56,12 +56,10 @@ export const useSessionStore = defineStore('session', {
 		 */
 		async fetchUserCourses(user_id: number): Promise<void> {
 			logger.debug(`[UserStore/fetchUserCourses] fetching courses for user #${user_id}`);
-			const user_response = await api.get(`users/${user_id}`);
 			const response = await api.get(`users/${user_id}/courses`);
 			if (response.status === 200) {
 				this.user_courses = (response.data as ParseableUserCourse[])
 					.map(user_course => new UserCourse({
-						username: (user_response.data as ParseableUser).username,
 						course_id: user_course.course_id,
 						user_id: user_course.user_id,
 						visible: user_course.visible,

--- a/tests/stores/session.spec.ts
+++ b/tests/stores/session.spec.ts
@@ -73,21 +73,22 @@ describe('Session Store', () => {
 			non_neg_fields: ['user_id']
 		});
 
+		// Fetch the user lisa.  This is used below.
+		lisa = new User(await getUser('lisa'));
+
 		lisa_courses = users_to_parse.filter(user => user.username === 'lisa')
 			.map(user_course => {
 				const course = courses_from_csv.find(c => c.course_name == user_course.course_name)
 					?? new Course();
 				return new UserCourse({
 					course_name: course.course_name,
-					username: user_course.username as string,
+					user_id: lisa.user_id,
 					visible: course.visible,
 					role: user_course.role as string,
 					course_dates: course.course_dates
 				});
 			});
 
-		// Fetch the user lisa.  This is used below.
-		lisa = new User(await getUser('lisa'));
 	});
 
 	describe('Testing the Session Store.', () => {


### PR DESCRIPTION
Minor fixes:

- UserCourses.vue was trying to load courses from store before they were populated -- merge both calls into async setup and await population of data before returning tracked objects
- session.ts attempts to fetchGlobalUser, but permissions cannot be set because our user is not "in" a course at the point when this is called
- course.ts requires username, which forces us to perform the fetch above -- swap username out for user_id, which no longer necessitates an API call
- update testing suite to reflect changes to the model
- also implement HTTP codes for failure to authenticate or access data for which permissions are insufficient