### PR TITLE
fix route guards, use lazy regex route match

### DIFF
--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -20,6 +20,7 @@ const routes: RouteRecordRaw[] = [
 			},
 			{
 				path: 'login',
+				name: 'login',
 				component: () =>
 					import(
 						/* webpackChunkName: "Login" */
@@ -28,6 +29,7 @@ const routes: RouteRecordRaw[] = [
 			},
 			{
 				path: 'users/:user_id/courses',
+				name: 'user_courses',
 				component: () =>
 					import(
 						/* webpackChunkName: "UserCourses" */

--- a/src/stores/permissions.ts
+++ b/src/stores/permissions.ts
@@ -40,7 +40,7 @@ export const usePermissionStore = defineStore('permission', {
 			const role = session_store.course.role ?? '';
 			const user = session_store.user;
 			const perms = state.ui_permissions.filter(perm => {
-				const re = new RegExp(perm.route.replace('*', '.*'));
+				const re = new RegExp(perm.route.replace('*', '.*?'));
 				return re.test(route.path);
 			});
 

--- a/src/stores/session.ts
+++ b/src/stores/session.ts
@@ -41,7 +41,7 @@ export const useSessionStore = defineStore('session', {
 		user_courses: []
 	}),
 	getters: {
-		full_name: (state): string => `${state.user?.first_name ?? ''} ${state.user?.last_name ?? ''} `,
+		full_name: (state): string => `${state.user?.first_name ?? ''} ${state.user?.last_name ?? ''}`,
 		getUser: (state): User => new User(state.user)
 	},
 	actions: {


### PR DESCRIPTION
Addresses issues described in comments on openwebwork/webwork3#95

[Vue Router v4 documentation on using `next`](https://router.vuejs.org/guide/advanced/navigation-guards.html#optional-third-argument-next)

Removed stray space from the end of user.fullname
Used lazy wildcard when turning dynamic routes into regex