### PR TITLE
Track authentication w/ expiration, redirect after login

### DIFF
--- a/lib/WeBWorK3.pm
+++ b/lib/WeBWorK3.pm
@@ -62,6 +62,7 @@ sub startup ($app) {
 
 	# Handle all api route exceptions
 	$app->hook(around_dispatch => $WeBWorK3::Hooks::exception_handler);
+	$app->hook(after_dispatch => $WeBWorK3::Hooks::notify_expiry);
 
 	# The following defines the routes as well as handles whether a user has permission for each route
 	# The following routes need no authentication:

--- a/lib/WeBWorK3.pm
+++ b/lib/WeBWorK3.pm
@@ -62,7 +62,7 @@ sub startup ($app) {
 
 	# Handle all api route exceptions
 	$app->hook(around_dispatch => $WeBWorK3::Hooks::exception_handler);
-	$app->hook(after_dispatch => $WeBWorK3::Hooks::notify_expiry);
+	$app->hook(after_dispatch  => $WeBWorK3::Hooks::notify_expiry);
 
 	# The following defines the routes as well as handles whether a user has permission for each route
 	# The following routes need no authentication:

--- a/lib/WeBWorK3/Hooks.pm
+++ b/lib/WeBWorK3/Hooks.pm
@@ -27,4 +27,9 @@ our $exception_handler = sub ($next, $c) {
 	}
 };
 
+our $notify_expiry = sub ($c) {
+	$c->res->headers->header('x-expiry' => time + $c->app->sessions->default_expiration)
+		if ($c->signature_exists());
+};
+
 1;

--- a/src/boot/axios.ts
+++ b/src/boot/axios.ts
@@ -1,5 +1,6 @@
 import { boot } from 'quasar/wrappers';
 import axios, { AxiosInstance } from 'axios';
+import { useSessionStore } from 'src/stores/session';
 
 declare module '@vue/runtime-core' {
 	interface ComponentCustomProperties {
@@ -15,6 +16,14 @@ declare module '@vue/runtime-core' {
 // for each client)
 
 const api = axios.create({ baseURL: (process.env.VUE_ROUTER_BASE ?? '') + 'api' });
+
+api.interceptors.response.use((response) => {
+	const session = useSessionStore();
+	// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+	const expiry = response.headers['x-expiry'] as number ?? 0;
+	session.updateExpiry(expiry * 1000);
+	return response;
+});
 
 export default boot(({ app }) => {
 	// for use inside Vue files (Options API) through this.$axios and this.$api

--- a/src/components/common/Login.vue
+++ b/src/components/common/Login.vue
@@ -62,14 +62,17 @@ const login = async () => {
 		// success
 		session.updateSessionInfo(session_info);
 
+		// permissions require access to user courses and respective roles
+		await session.fetchUserCourses(session_info.user.user_id);
 		await permission_store.fetchRoles();
 		await permission_store.fetchRoutePermissions();
 
-		if (session_info?.user?.is_admin) {
-			void router.push('/admin');
-		} else if (session && session.user && session.user.user_id) {
-			void router.push(`/users/${session.user.user_id}/courses`);
-		}
+		let forward = localStorage.getItem('afterLogin');
+		forward ||= (session_info.user.is_admin) ?
+			'/admin' :
+			`/users/${session.user.user_id}/courses`;
+		localStorage.removeItem('afterLogin');
+		void router.push(forward);
 	}
 };
 </script>

--- a/src/components/common/UserCourses.vue
+++ b/src/components/common/UserCourses.vue
@@ -36,7 +36,6 @@ import { computed } from 'vue';
 import { useRouter } from 'vue-router';
 
 import { useSessionStore } from 'src/stores/session';
-import { parseNonNegInt } from 'src/common/models/parsers';
 
 const session = useSessionStore();
 const router = useRouter();
@@ -46,9 +45,6 @@ const course_types = computed(() => [
 	{ name: 'Student', courses: student_courses.value },
 	{ name: 'Instrutor', courses: instructor_courses.value }
 ]);
-
-// fetch the data when the view is created and the data is already being observed
-if (session) await session.fetchUserCourses(parseNonNegInt(session.user.user_id));
 
 const student_courses = computed(() =>
 	// for some reason on load the user_course.role is undefined.

--- a/src/components/student/Student.vue
+++ b/src/components/student/Student.vue
@@ -31,18 +31,18 @@ const loadStudentSets = async () => {
 	}
 };
 
-if (session_store.user.user_id) await session_store.fetchUserCourses(session_store.user.user_id)
-	.then(async () => {
-		const course_id = parseRouteCourseID(route);
-		const course = session_store.user_courses.find(c => c.course_id === course_id);
-		if (course) {
-			session_store.setCourse({
-				course_id: course_id,
-				course_name: course.course_name
-			});
-		}
-		await loadStudentSets();
+const course_id = parseRouteCourseID(route);
+const course = session_store.user_courses.find(c => c.course_id === course_id);
+if (course) {
+	session_store.setCourse({
+		course_id: course_id,
+		course_name: course.course_name
 	});
+} else {
+	logger.warn(`Can't find ${course_id} in ${session_store.user_courses
+		.map((c) => c.course_id).join(', ')}`);
+}
+await loadStudentSets();
 
 watch(() => session_store.course.course_id, async () => {
 

--- a/src/pages/instructor/Instructor.vue
+++ b/src/pages/instructor/Instructor.vue
@@ -31,19 +31,16 @@ export default defineComponent({
 		const route = useRoute();
 
 		const course_id = parseRouteCourseID(route);
-		if (session.user.user_id) await session.fetchUserCourses(session.user.user_id)
-			.then(() => {
-				const course = session.user_courses.find(c => c.course_id === course_id);
-				if (course) {
-					session.setCourse({
-						course_id,
-						course_name: course.course_name
-					});
-				} else {
-					logger.warn(`Can't find ${course_id} in ${session.user_courses
-						.map((c) => c.course_id).join(', ')}`);
-				}
+		const course = session.user_courses.find(c => c.course_id === course_id);
+		if (course) {
+			session.setCourse({
+				course_id,
+				course_name: course.course_name
 			});
+		} else {
+			logger.warn(`Can't find ${course_id} in ${session.user_courses
+				.map((c) => c.course_id).join(', ')}`);
+		}
 		await users.fetchGlobalCourseUsers(course_id);
 		await users.fetchCourseUsers(course_id);
 		await problem_sets.fetchProblemSets(course_id);

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -32,20 +32,19 @@ export default route(() => {
 	});
 
 	router.beforeResolve((to) => {
-		// must be logged in, or else headed to the login page
 		const session_store = useSessionStore();
-		if (!session_store.authenticated && to.name !== 'login') {
-			// dump current session and redirect to login
-			session_store.logout();
+
+		// Redirect to the login page if user is not authenticated
+		if (!session_store.authIsCurrent() && to.name !== 'login') {
+			localStorage.setItem('afterLogin', to.path);
 			return { name: 'login' };
 		};
 
-		// otherwise, we're logged in, so check permissions on the route
+		// user is logged in, so check permissions on the route
 		const permissions_store = usePermissionStore();
-		const perm = permissions_store.hasRoutePermission(to);
-		if (!perm) {
+		if (!permissions_store.hasRoutePermission(to)) {
 			const user = session_store.getUser;
-			logger.error(`[routing] User #${user.user_id} does not have the permission to visit ${to.fullPath}`);
+			logger.warn(`[routing] User #${user.user_id} does not have the permission to visit ${to.fullPath}`);
 			return { name: 'user_courses', params: { user_id: user.user_id } };
 		}
 	});

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -34,7 +34,11 @@ export default route(() => {
 	router.beforeResolve((to) => {
 		// must be logged in, or else headed to the login page
 		const session_store = useSessionStore();
-		if (!session_store.logged_in && to.name !== 'login') return { name: 'login' };
+		if (!session_store.authenticated && to.name !== 'login') {
+			// dump current session and redirect to login
+			session_store.logout();
+			return { name: 'login' };
+		};
 
 		// otherwise, we're logged in, so check permissions on the route
 		const permissions_store = usePermissionStore();

--- a/src/stores/session.ts
+++ b/src/stores/session.ts
@@ -22,6 +22,7 @@ interface CourseInfo {
 // SessionState should contain a de facto User, already parsed
 export interface SessionState {
 	logged_in: boolean;
+	expiry: number;
 	user: User;
 	course: CourseInfo;
 	user_courses: UserCourse[];
@@ -32,6 +33,7 @@ export const useSessionStore = defineStore('session', {
 	persist: true,
 	state: (): SessionState => ({
 		logged_in: false,
+		expiry: 0,
 		user: new User({ username: 'logged_out' }),
 		course: {
 			course_id: 0,
@@ -42,9 +44,13 @@ export const useSessionStore = defineStore('session', {
 	}),
 	getters: {
 		full_name: (state): string => `${state.user?.first_name ?? ''} ${state.user?.last_name ?? ''}`,
-		getUser: (state): User => new User(state.user)
+		getUser: (state): User => new User(state.user),
+		authenticated: (state): boolean => state.logged_in && state.expiry > Date.now(),
 	},
 	actions: {
+		updateExpiry(expiry: number): void {
+			this.expiry = expiry;
+		},
 		updateSessionInfo(session_info: SessionInfo): void {
 			this.logged_in = session_info.logged_in;
 			if (this.logged_in) {


### PR DESCRIPTION
## Enforcing Authentication & Permissions

So the thing about secure cookies is that we cannot access them from our application layer. (Even the `set-cookie` field in the response header is inaccessible from axios!)

### WeBWorK3 changes
- hook into `after_dispatch`, add custom header field to the response if it 'belongs' to an authenticated user session
  - `x-expiry:` is a unix timestamp (now + expiration)

### Front-end changes
- hook into axios via `interceptors.response` and grab the custom header field
  - stick the result into the session store as `expiry` (👍 / 👎 ?)
- add an action to the session store to check logged_in && test if `expiry` is in the past
  - I *had* this as a getter -- but pinia apparently stashes getter results until its state changes (BAD! login being current does **not** depend on state) -- so this is an _action_
  - dump session via `logout` if session expired
- add route-guard via `beforeResolve` in the router
  - if there is no 'current' session, stash the target route in local storage and direct user to login
  - after successful login, pull target route in Login.vue
  - target route might be course- or user-specific, so login must load user_courses into session **before** we get to permissions (i.e. _before_ redirect)
  - update all other components that were loading user_courses
- refine route permissions checking
  - previously assumed that the course would be 'loaded' in session (happens via navigation through user_courses page)
  - now we might be skipping that because of redirection, so route check must use all user_courses in session